### PR TITLE
test: add isolated WordPress/WooCommerce E2E regression flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,15 +236,21 @@ jobs:
                   tools: composer:v2
                   coverage: none
             - run: composer install --no-interaction --prefer-dist
-            - name: Prepare WordPress site
-              run: make acceptance_prepare
+            - name: Prepare WordPress and WooCommerce site
+              run: make acceptance_checkout_prepare
             - uses: actions/setup-node@v7
               with:
                   node-version: 22
             - run: npm install --no-audit --no-fund
             - run: npx playwright install --with-deps chromium
             - name: Run Playwright browser tests
-              run: npm run test:e2e
+              run: |
+                  set -euo pipefail
+                  order_id="$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id)"
+                  request_id="$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id)"
+                  WP_ACCEPTANCE_FIXTURE_ORDER_ID="$order_id" \
+                  WP_ACCEPTANCE_FIXTURE_REQUEST_ID="$request_id" \
+                  npm run test:e2e
             - uses: actions/upload-artifact@v7
               if: ${{ failure() }}
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+    workflow_dispatch:
     pull_request:
     push:
         branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,3 +253,51 @@ jobs:
                       playwright-report
                       test-results
                   if-no-files-found: warn
+
+    acceptance-e2e:
+        runs-on: ubuntu-latest
+        name: Isolated WordPress/WooCommerce E2E (PHP 8.4)
+        timeout-minutes: 35
+
+        steps:
+            - uses: actions/checkout@v7
+
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  tools: composer:v2
+                  coverage: none
+
+            - uses: actions/setup-node@v7
+              with:
+                  node-version: 22
+
+            - name: Install PHP dependencies
+              run: composer install --no-interaction --prefer-dist
+
+            - name: Install Node dependencies
+              run: npm install --no-audit --no-fund
+
+            - name: Install Chromium system dependencies
+              run: npx playwright install --with-deps chromium
+
+            - name: Run isolated WordPress/WooCommerce E2E flow
+              run: make acceptance_e2e_test
+
+            - name: Collect E2E diagnostics
+              if: ${{ failure() }}
+              run: |
+                  set +e
+                  mkdir -p /tmp/bluem-acceptance-e2e-diagnostics
+                  docker compose ps -a > /tmp/bluem-acceptance-e2e-diagnostics/compose-ps.txt || true
+                  docker compose logs --no-color > /tmp/bluem-acceptance-e2e-diagnostics/compose-logs.txt || true
+                  cp -R tests/_output /tmp/bluem-acceptance-e2e-diagnostics/codeception-output 2>/dev/null || true
+                  cp -R test-results /tmp/bluem-acceptance-e2e-diagnostics/playwright-results 2>/dev/null || true
+
+            - name: Upload E2E diagnostics
+              if: ${{ failure() }}
+              uses: actions/upload-artifact@v7
+              with:
+                  name: acceptance-e2e-diagnostics
+                  path: /tmp/bluem-acceptance-e2e-diagnostics
+                  if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ docker
 /tests/Support/_generated/UnitTesterActions.php
 /.php-cs-fixer.cache
 /tests/_output/
+/test-results/
+/playwright-report/
+/blob-report/
 build
 tools
 tools/*

--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,13 @@ playwright_install:
 	npx playwright install chromium
 
 .PHONY: acceptance_browser_test
-acceptance_browser_test: acceptance_prepare playwright_install
+acceptance_browser_test: acceptance_checkout_prepare playwright_install
 	@printf 'Playwright browser tests:\n';
-	npm run test:e2e
+	@order_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id); \
+		request_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id); \
+		export WP_ACCEPTANCE_FIXTURE_ORDER_ID=$$order_id; \
+		export WP_ACCEPTANCE_FIXTURE_REQUEST_ID=$$request_id; \
+		npm run test:e2e
 
 .PHONY: acceptance_e2e_test
 acceptance_e2e_test: playwright_install

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ acceptance_e2e_test: playwright_install
 		php vendor/bin/codecept run Acceptance --steps
 	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
 		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-request-flow.php
+	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-in-progress-flow.php; \
+		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-prepare-fixtures.php
 	@order_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id); \
 		request_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id); \
 		export WP_ACCEPTANCE_FIXTURE_ORDER_ID=$$order_id; \

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,11 @@ acceptance_e2e_test: playwright_install
 	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
 		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-in-progress-flow.php; \
 		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-prepare-fixtures.php
+	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-prepare-advanced-fixtures.php; \
+		docker compose run --rm wpcli --allow-root rewrite flush --hard; \
+		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-mandate-flow.php; \
+		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-identity-flow.php
 	@order_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id); \
 		request_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id); \
 		export WP_ACCEPTANCE_FIXTURE_ORDER_ID=$$order_id; \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ help:
 	@printf '\- make acceptance_smoke_test\n'
 	@printf '\- make acceptance_settings_test\n'
 	@printf '\- make acceptance_checkout_test\n'
+	@printf '\- make acceptance_e2e_test\n'
 	@printf '\- make acceptance_browser_test\n'
 	@printf '\- make integration_test\n'
 	@printf '\- make add_git_hooks\n'
@@ -67,7 +68,7 @@ acceptance_test: acceptance_prepare
 .PHONY: acceptance_prepare
 acceptance_prepare: copy-to-docker
 	@printf 'Starting Docker WordPress test site:\n';
-	docker compose up -d db wordpress
+	docker compose up -d db wordpress mock-bluem
 	WP_ACCEPTANCE_URL="$(ACCEPTANCE_URL)" \
 	WP_ACCEPTANCE_ADMIN_USER="$(WP_ADMIN_USER)" \
 	WP_ACCEPTANCE_ADMIN_PASSWORD="$(WP_ADMIN_PASSWORD)" \
@@ -117,6 +118,22 @@ playwright_install:
 acceptance_browser_test: acceptance_prepare playwright_install
 	@printf 'Playwright browser tests:\n';
 	npm run test:e2e
+
+.PHONY: acceptance_e2e_test
+acceptance_e2e_test: playwright_install
+	@printf 'Broad isolated WordPress/WooCommerce end-to-end flow:\n';
+	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		$(MAKE) acceptance_checkout_prepare
+	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		php vendor/bin/codecept run Acceptance --steps
+	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-request-flow.php
+	@order_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id); \
+		request_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id); \
+		export WP_ACCEPTANCE_FIXTURE_ORDER_ID=$$order_id; \
+		export WP_ACCEPTANCE_FIXTURE_REQUEST_ID=$$request_id; \
+		export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		npm run test:e2e
 
 .PHONY: integration_test
 integration_test:

--- a/bluem-idin.php
+++ b/bluem-idin.php
@@ -926,7 +926,7 @@ function bluem_idin_shortcode_callback(): void
     $bluem_config->brandID = $bluem_config->IDINBrandID ?? $bluem_config->brandID ?? '';
 
     try {
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (Exception $e) {
         return;
         // @todo: deal with incorrectly configured Bluem here
@@ -1584,7 +1584,7 @@ function bluem_idin_validation_needed(): bool
     }
 
     try {
-        $bluem = new Bluem($bluem_config);
+    $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (Exception $e) {
         // @todo: deal with non-configured bluem brandID, or assert that is has been configured on a higher level
         return false;
@@ -1693,7 +1693,7 @@ function bluem_idin_execute($callback = null, $redirect = true, $redirect_page =
     $bluem_config->brandID = $bluem_config->IDINBrandID;
 
     try {
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (InvalidBluemConfigurationException $e) {
         printf(
             /* translators: %s: Error message */

--- a/bluem-integrations.php
+++ b/bluem-integrations.php
@@ -237,7 +237,7 @@ function bluem_woocommerce_integration_wpcf7_ajax()
                     $bluem_config->eMandateReason = 'eMandate ' . $debtorReference;
                 }
 
-                $bluem = new Bluem($bluem_config);
+                $bluem = bluem_woocommerce_create_client($bluem_config);
 
                 $mandate_id_counter = get_option('bluem_woocommerce_mandate_id_counter');
 
@@ -423,7 +423,7 @@ function bluem_woocommerce_integration_wpcf7_submit()
                 }
 
                 try {
-                    $bluem = new Bluem($bluem_config);
+                    $bluem = bluem_woocommerce_create_client($bluem_config);
                 } catch (InvalidBluemConfigurationException $e) {
                     exit('Error instantiating Bluem: Invalid configuration');
                 }
@@ -546,7 +546,7 @@ function bluem_woocommerce_integration_wpcf7_callback()
     }
 
     try {
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (Exception $e) {
         // @todo: deal with incorrectly setup Bluem
     }
@@ -863,7 +863,7 @@ function bluem_woocommerce_integration_gform_submit($entry, $form)
             }
 
             try {
-                $bluem = new Bluem($bluem_config);
+                    $bluem = bluem_woocommerce_create_client($bluem_config);
             } catch (Exception $e) {
                 echo ('Could not process the Gravity Forms request correctly; check your settings.');
                 die();
@@ -1042,7 +1042,7 @@ function bluem_woocommerce_integration_gform_callback()
     }
 
     try {
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (Exception $e) {
         bluem_dialogs_render_prompt(esc_html__(
             "Error: the Bluem configuration is not correct even though Gravity Forms is active. 

--- a/bluem-mandates-instant.php
+++ b/bluem-mandates-instant.php
@@ -53,7 +53,7 @@ function bluem_mandates_instant_request(): void
             $bluem_config->eMandateReason = esc_html__('Direct debit mandate ', 'bluem') . $debtorReference;
         }
 
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
 
         $mandate_id_counter = get_option('bluem_woocommerce_mandate_id_counter');
 
@@ -161,7 +161,7 @@ function bluem_mandates_instant_callback()
     $bluem_config = bluem_woocommerce_get_config();
 
     try {
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (Exception $e) {
         // @todo: deal with incorrectly setup Bluem
     }

--- a/bluem-mandates-shortcode.php
+++ b/bluem-mandates-shortcode.php
@@ -144,7 +144,7 @@ function bluem_mandate_shortcode_execute(): void
             $bluem_config->eMandateReason = 'Direct debit mandate ' . $debtorReference;
         }
 
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
 
         $mandate_id_counter = get_option('bluem_woocommerce_mandate_id_counter');
 
@@ -281,7 +281,7 @@ function bluem_mandate_shortcode_callback(): void
     $storage = is_array($storage) ? $storage : [];
 
     try {
-        $bluem = new Bluem($bluem_config);
+        $bluem = bluem_woocommerce_create_client($bluem_config);
     } catch (Exception $e) {
         // @todo: deal with incorrectly setup Bluem
         // $e->getMessage();

--- a/bluem.php
+++ b/bluem.php
@@ -2241,14 +2241,24 @@ function bluem_display_module_notices( $notices, $title = '', $btn_link = '', $b
 // WooCommerce uses a different order-editor screen depending on whether HPOS
 // is enabled. Register the request information for both storage modes.
 add_action( 'add_meta_boxes_woocommerce_page_wc-orders', 'bluem_order_requests_metabox', 99, 1 );
-add_action( 'add_meta_boxes_shop_order', 'bluem_order_requests_metabox', 99, 1 );
-function bluem_order_requests_metabox( $order )
+add_action( 'add_meta_boxes', 'bluem_legacy_order_requests_metabox', 99, 2 );
+
+function bluem_legacy_order_requests_metabox( $post_type, $post )
+{
+    if ( $post_type !== 'shop_order' ) {
+        return;
+    }
+
+    bluem_order_requests_metabox( $post, 'shop_order' );
+}
+
+function bluem_order_requests_metabox( $order, $screen = 'woocommerce_page_wc-orders' )
 {
     add_meta_box(
             'woocommerce-shipping-details',
             esc_html__('Bluem request(s)', 'bluem'),
             'bluem_order_requests_metabox_content',
-            'woocommerce_page_wc-orders',
+            $screen,
             'normal',
             'high'
     );

--- a/bluem.php
+++ b/bluem.php
@@ -2238,7 +2238,10 @@ function bluem_display_module_notices( $notices, $title = '', $btn_link = '', $b
  *  Adding Meta container admin shop_order pages
  */
 
+// WooCommerce uses a different order-editor screen depending on whether HPOS
+// is enabled. Register the request information for both storage modes.
 add_action( 'add_meta_boxes_woocommerce_page_wc-orders', 'bluem_order_requests_metabox', 99, 1 );
+add_action( 'add_meta_boxes_shop_order', 'bluem_order_requests_metabox', 99, 1 );
 function bluem_order_requests_metabox( $order )
 {
     add_meta_box(
@@ -2256,8 +2259,10 @@ function bluem_order_requests_metabox( $order )
  *
  * @return void
  */
-function bluem_order_requests_metabox_content($post) {
-    $order_id = $post->ID;
+function bluem_order_requests_metabox_content($order) {
+    $order_id = is_object($order) && method_exists($order, 'get_id')
+        ? $order->get_id()
+        : $order->ID;
 
     $requests_links = bluem_db_get_links_for_order( $order_id );
 

--- a/bluem.php
+++ b/bluem.php
@@ -52,6 +52,27 @@ use Bluem\Wordpress\Observability\BluemActivationNotifier;
 use Bluem\Wordpress\Observability\BluemSentry;
 use Bluem\Wordpress\Support\BluemComposerDependencyVersion;
 
+/**
+ * Create a Bluem client while allowing acceptance tests to replace only its
+ * HTTP transport. Request construction and response parsing remain real.
+ *
+ * @param object $config Bluem configuration object.
+ */
+function bluem_woocommerce_create_client(object $config): Bluem {
+    $transport = apply_filters('bluem_woocommerce_http_transport', null, $config);
+
+    $mockEndpoint = getenv('BLUEM_ACCEPTANCE_MOCK_URL');
+    if ($transport === null && is_string($mockEndpoint) && $mockEndpoint !== '') {
+        $transport = new \Bluem\Wordpress\Testing\BluemAcceptanceHttpTransport($mockEndpoint);
+    }
+
+    if ($transport instanceof HttpTransportInterface) {
+        return new Bluem($config, $transport);
+    }
+
+    return new Bluem($config);
+}
+
 // Initialize before loading the feature modules so uncaught Bluem errors can be captured.
 BluemSentry::initialize();
 
@@ -740,7 +761,7 @@ function bluem_update_request_by_id( $request_id ) {
         $bluem_config->environment = $bluem_env;
     }
 
-    $bluem = new Bluem( $bluem_config );
+    $bluem = bluem_woocommerce_create_client( $bluem_config );
 
     // Check for order
     if ( ! empty( $request->order_id ) ) {

--- a/bluem.php
+++ b/bluem.php
@@ -66,7 +66,7 @@ function bluem_woocommerce_create_client(object $config): Bluem {
         $transport = new \Bluem\Wordpress\Testing\BluemAcceptanceHttpTransport($mockEndpoint);
     }
 
-    if ($transport instanceof HttpTransportInterface) {
+    if ($transport instanceof \Bluem\BluemPHP\Transport\HttpTransportInterface) {
         return new Bluem($config, $transport);
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
       BLUEM_ACCEPTANCE_MOCK_URL: ${BLUEM_ACCEPTANCE_MOCK_URL:-}
   mock-bluem:
-    image: php:8.4-cli
+    image: wordpress:cli-php8.4
     volumes:
       - ./docker/mock-bluem:/var/www/mock:ro
     command: php -S 0.0.0.0:8080 -t /var/www/mock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
+      BLUEM_ACCEPTANCE_MOCK_URL: ${BLUEM_ACCEPTANCE_MOCK_URL:-}
   wpcli:
     depends_on:
       - wordpress
@@ -48,3 +49,9 @@ services:
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
+      BLUEM_ACCEPTANCE_MOCK_URL: ${BLUEM_ACCEPTANCE_MOCK_URL:-}
+  mock-bluem:
+    image: php:8.4-cli
+    volumes:
+      - ./docker/mock-bluem:/var/www/mock:ro
+    command: php -S 0.0.0.0:8080 -t /var/www/mock

--- a/docker/mock-bluem/index.php
+++ b/docker/mock-bluem/index.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+$contentType = $_SERVER['HTTP_CONTENT_TYPE'] ?? '';
+$requestBody = file_get_contents('php://input') ?: '';
+
+if (!str_contains($contentType, 'type=')) {
+    http_response_code(400);
+    echo '<Error>Missing Bluem transaction type</Error>';
+    exit;
+}
+
+$transactionType = strtoupper((string) preg_replace('/.*type=([^; ]+).*/', '$1', $contentType));
+$isStatusRequest = $transactionType === 'PSX';
+$transactionId = 'ACCEPTANCE-TRANSACTION-1';
+$entranceCode = 'ACCEPTANCE-ENTRANCE-1';
+$debtorReference = 'ACCEPTANCE-ORDER-1';
+
+header('Content-Type: application/xml; charset=UTF-8');
+
+if ($isStatusRequest) {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<EPaymentInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="StatusUpdate" version="1.0">
+    <PaymentStatusUpdate entranceCode="{$entranceCode}">
+        <CreationDateTime>2026-08-03T00:00:00Z</CreationDateTime>
+        <PaymentReference>ACCEPTANCE-PAYMENT-1</PaymentReference>
+        <DebtorReference>{$debtorReference}</DebtorReference>
+        <TransactionID>{$transactionId}</TransactionID>
+        <Status>Success</Status>
+        <Amount>12.34</Amount>
+        <AmountPaid>12.34</AmountPaid>
+        <Currency>EUR</Currency>
+        <PaymentMethod>IDEAL</PaymentMethod>
+    </PaymentStatusUpdate>
+</EPaymentInterface>
+XML;
+    exit;
+}
+
+echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<EPaymentInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="TransactionRequest" version="1.0">
+    <PaymentTransactionResponse entranceCode="{$entranceCode}">
+        <TransactionURL>https://mock-bluem.invalid/payment/transaction/{$transactionId}</TransactionURL>
+        <TransactionID>{$transactionId}</TransactionID>
+        <DebtorReference>{$debtorReference}</DebtorReference>
+        <PaymentReference>ACCEPTANCE-PAYMENT-1</PaymentReference>
+    </PaymentTransactionResponse>
+</EPaymentInterface>
+XML;

--- a/docker/mock-bluem/index.php
+++ b/docker/mock-bluem/index.php
@@ -12,18 +12,38 @@ if (!str_contains($contentType, 'type=')) {
 }
 
 $transactionType = strtoupper((string) preg_replace('/.*type=([^; ]+).*/', '$1', $contentType));
-$isStatusRequest = $transactionType === 'PSX';
+$isPaymentStatusRequest = $transactionType === 'PSX';
+$isMandateRequest = $transactionType === 'TRX';
+$isMandateStatusRequest = $transactionType === 'SRX';
+$isIdentityRequest = $transactionType === 'ITX';
+$isIdentityStatusRequest = $transactionType === 'ISX';
+$isStatusRequest = $isPaymentStatusRequest || $isMandateStatusRequest || $isIdentityStatusRequest;
 $transactionId = 'ACCEPTANCETX1';
 $entranceCode = 'ACCEPTANCEENTRANCE1';
 $debtorReference = 'ACCEPTANCEORDER1';
+$mandateId = 'ACCEPTANCEMANDATE1';
 
-if ($isStatusRequest && preg_match('/<TransactionID>([^<]+)<\/TransactionID>/', $requestBody, $matches) === 1) {
+if (($isPaymentStatusRequest || $isIdentityStatusRequest) && preg_match('/<TransactionID>([^<]+)<\/TransactionID>/', $requestBody, $matches) === 1) {
     $transactionId = (string) $matches[1];
+}
+
+if (($isMandateRequest || $isMandateStatusRequest) && preg_match('/<MandateID>([^<]+)<\/MandateID>/', $requestBody, $matches) === 1) {
+    $mandateId = (string) $matches[1];
+}
+
+if ($isMandateRequest) {
+    $transactionId = 'ACCEPTANCEMANDATETX1';
+    $entranceCode = 'ACCEPTANCEMANDATEENTRANCE1';
+}
+
+if ($isIdentityRequest) {
+    $transactionId = 'ACCEPTANCEIDINTX1';
+    $entranceCode = 'ACCEPTANCEIDINENTRANCE1';
 }
 
 header('Content-Type: application/xml; charset=UTF-8');
 
-if ($isStatusRequest) {
+if ($isPaymentStatusRequest) {
     $status = $transactionId === 'ACCEPTANCEPENDING1' ? 'Pending' : 'Success';
     echo <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -40,6 +60,74 @@ if ($isStatusRequest) {
         <PaymentMethod>IDEAL</PaymentMethod>
     </PaymentStatusUpdate>
 </EPaymentInterface>
+XML;
+    exit;
+}
+
+if ($isMandateStatusRequest) {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<EMandateInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="StatusUpdate" version="1.0">
+    <EMandateStatusUpdate entranceCode="ACCEPTANCEMANDATEENTRANCE1">
+        <EMandateStatus>
+            <Status>Success</Status>
+            <MandateID>{$mandateId}</MandateID>
+            <PurchaseID>ACCEPTANCEPURCHASE1</PurchaseID>
+            <AcceptanceReport>
+                <DebtorIBAN>NL66ABNA4097012428</DebtorIBAN>
+                <DebtorBankID>ABNANL2A</DebtorBankID>
+                <DebtorAccountName>Bluem Acceptance</DebtorAccountName>
+                <MaxAmount>250.00</MaxAmount>
+            </AcceptanceReport>
+        </EMandateStatus>
+    </EMandateStatusUpdate>
+</EMandateInterface>
+XML;
+    exit;
+}
+
+if ($isIdentityStatusRequest) {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<IdentityInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="StatusUpdate" version="1.0">
+    <IdentityStatusUpdate entranceCode="ACCEPTANCEIDINENTRANCE1">
+        <AuthenticationAuthorityID>ACCEPTANCEAUTHORITY1</AuthenticationAuthorityID>
+        <Status>Success</Status>
+        <IdentityReport>
+            <ReportStatus>Verified</ReportStatus>
+            <CustomerName>Bluem Acceptance</CustomerName>
+            <AgeCheckResponse>Passed</AgeCheckResponse>
+        </IdentityReport>
+    </IdentityStatusUpdate>
+</IdentityInterface>
+XML;
+    exit;
+}
+
+if ($isMandateRequest) {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<EMandateInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="TransactionRequest" version="1.0">
+    <EMandateTransactionResponse entranceCode="{$entranceCode}">
+        <TransactionURL>https://mock-bluem.invalid/mandate/transaction/{$transactionId}</TransactionURL>
+        <TransactionID>{$transactionId}</TransactionID>
+        <MandateID>{$mandateId}</MandateID>
+    </EMandateTransactionResponse>
+</EMandateInterface>
+XML;
+    exit;
+}
+
+if ($isIdentityRequest) {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<IdentityInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="TransactionRequest" version="1.0">
+    <IdentityTransactionResponse entranceCode="{$entranceCode}">
+        <TransactionURL>https://mock-bluem.invalid/identity/transaction/{$transactionId}</TransactionURL>
+        <TransactionID>{$transactionId}</TransactionID>
+        <DebtorReference>ACCEPTANCEIDENTITY1</DebtorReference>
+    </IdentityTransactionResponse>
+</IdentityInterface>
 XML;
     exit;
 }

--- a/docker/mock-bluem/index.php
+++ b/docker/mock-bluem/index.php
@@ -13,9 +13,9 @@ if (!str_contains($contentType, 'type=')) {
 
 $transactionType = strtoupper((string) preg_replace('/.*type=([^; ]+).*/', '$1', $contentType));
 $isStatusRequest = $transactionType === 'PSX';
-$transactionId = 'ACCEPTANCE-TRANSACTION-1';
-$entranceCode = 'ACCEPTANCE-ENTRANCE-1';
-$debtorReference = 'ACCEPTANCE-ORDER-1';
+$transactionId = 'ACCEPTANCETX1';
+$entranceCode = 'ACCEPTANCEENTRANCE1';
+$debtorReference = 'ACCEPTANCEORDER1';
 
 header('Content-Type: application/xml; charset=UTF-8');
 

--- a/docker/mock-bluem/index.php
+++ b/docker/mock-bluem/index.php
@@ -17,9 +17,14 @@ $transactionId = 'ACCEPTANCETX1';
 $entranceCode = 'ACCEPTANCEENTRANCE1';
 $debtorReference = 'ACCEPTANCEORDER1';
 
+if ($isStatusRequest && preg_match('/<TransactionID>([^<]+)<\/TransactionID>/', $requestBody, $matches) === 1) {
+    $transactionId = (string) $matches[1];
+}
+
 header('Content-Type: application/xml; charset=UTF-8');
 
 if ($isStatusRequest) {
+    $status = $transactionId === 'ACCEPTANCEPENDING1' ? 'Pending' : 'Success';
     echo <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <EPaymentInterface createDateTime="2026-08-03T00:00:00Z" messageCount="1" mode="direct" senderID="acceptance" type="StatusUpdate" version="1.0">
@@ -28,7 +33,7 @@ if ($isStatusRequest) {
         <PaymentReference>ACCEPTANCE-PAYMENT-1</PaymentReference>
         <DebtorReference>{$debtorReference}</DebtorReference>
         <TransactionID>{$transactionId}</TransactionID>
-        <Status>Success</Status>
+        <Status>{$status}</Status>
         <Amount>12.34</Amount>
         <AmountPaid>12.34</AmountPaid>
         <Currency>EUR</Currency>

--- a/docs/acceptance-testing-plan.md
+++ b/docs/acceptance-testing-plan.md
@@ -23,6 +23,10 @@ deterministic order/request fixtures, and the main Playwright admin
 interactions. Future extensions can add additional payment methods, webhook
 variants, and cart-level checkout submission scenarios.
 
+Potential plugin/library defects found while extending this flow are tracked
+separately in [docs/known-issues.md](known-issues.md), rather than being
+silently encoded as test setup behavior.
+
 
 ## Broad isolated end-to-end flow
 
@@ -44,6 +48,10 @@ reactivate, admin and settings pages, WooCommerce activation and gateway
 registration, settings persistence, the order Bluem request metabox, the
 transaction detail page, payment request creation, mocked status retrieval,
 request persistence, and the resulting order transition to processing.
+
+The flow also exercises a mocked `Pending` callback and verifies that it keeps
+the order pending while persisting the in-progress request status. The browser
+transaction test opens the detail page and verifies the persisted transaction.
 
 The browser lifecycle test also completes the local Bluem activation form
 after reactivation because the plugin intentionally resets its setup guard on

--- a/docs/acceptance-testing-plan.md
+++ b/docs/acceptance-testing-plan.md
@@ -18,41 +18,11 @@ Implemented on the acceptance branch and wired into pull-request CI:
 - A separate WooCommerce-backed `checkout` acceptance group that verifies all five gateway links appear in WooCommerce payment settings without calling Bluem.
 - A Chromium Playwright job that verifies the JavaScript-capable Bluem settings page renders after administrator login.
 
-Still planned:
+The broad local flow now covers the first HTTP payment creation/callback path,
+deterministic order/request fixtures, and the main Playwright admin
+interactions. Future extensions can add additional payment methods, webhook
+variants, and cart-level checkout submission scenarios.
 
-- Full HTTP callback/webhook endpoint tests with mocked Bluem responses and order lookup.
-- A real cart/order checkout submission test once a deterministic product and payment fixture are added.
-- Broader Playwright interaction coverage for tabs, settings changes, and checkout UI behavior.
-
-## Broad isolated end-to-end flow
-
-Run the complete local regression flow with:
-
-```bash
-make acceptance_e2e_test
-```
-
-This target builds and copies the production-shaped plugin package, prepares
-WordPress and WooCommerce, creates a deterministic product/order/request
-fixture, runs the Codeception HTTP acceptance suite, follows a mocked Bluem
-payment creation and callback flow, and runs the Playwright admin checks.
-
-The flow covers:
-
-- opening the public, login, Bluem, WooCommerce, order, and transaction pages;
-- deactivating and reactivating Bluem through the WordPress plugin screen;
-- saving Bluem settings and a WooCommerce iDEAL gateway setting;
-- activating WooCommerce as the Bluem peer plugin and verifying all gateways;
-- rendering the Bluem request metabox on a fixture order;
-- opening a transaction list/detail view;
-- creating a payment through the real Bluem gateway code and handling a
-  successful callback over HTTP.
-
-The `mock-bluem` Compose service returns scoped XML fixtures based on the
-Bluem transaction content type. The plugin selects its injectable HTTP
-transport only when `BLUEM_ACCEPTANCE_MOCK_URL` is set, so the acceptance flow
-never contacts a Bluem host and normal local/production execution remains on
-the standard cURL transport.
 
 ## Broad isolated end-to-end flow
 

--- a/docs/acceptance-testing-plan.md
+++ b/docs/acceptance-testing-plan.md
@@ -24,6 +24,57 @@ Still planned:
 - A real cart/order checkout submission test once a deterministic product and payment fixture are added.
 - Broader Playwright interaction coverage for tabs, settings changes, and checkout UI behavior.
 
+## Broad isolated end-to-end flow
+
+Run the complete local regression flow with:
+
+```bash
+make acceptance_e2e_test
+```
+
+This target builds and copies the production-shaped plugin package, prepares
+WordPress and WooCommerce, creates a deterministic product/order/request
+fixture, runs the Codeception HTTP acceptance suite, follows a mocked Bluem
+payment creation and callback flow, and runs the Playwright admin checks.
+
+The flow covers:
+
+- opening the public, login, Bluem, WooCommerce, order, and transaction pages;
+- deactivating and reactivating Bluem through the WordPress plugin screen;
+- saving Bluem settings and a WooCommerce iDEAL gateway setting;
+- activating WooCommerce as the Bluem peer plugin and verifying all gateways;
+- rendering the Bluem request metabox on a fixture order;
+- opening a transaction list/detail view;
+- creating a payment through the real Bluem gateway code and handling a
+  successful callback over HTTP.
+
+The `mock-bluem` Compose service returns scoped XML fixtures based on the
+Bluem transaction content type. The plugin selects its injectable HTTP
+transport only when `BLUEM_ACCEPTANCE_MOCK_URL` is set, so the acceptance flow
+never contacts a Bluem host and normal local/production execution remains on
+the standard cURL transport.
+
+## Broad isolated end-to-end flow
+
+Run the full local regression flow with:
+
+```bash
+make acceptance_e2e_test
+```
+
+This target builds the current plugin package, starts WordPress, WooCommerce,
+MySQL, and a local Bluem mock service, then runs the existing Codeception suite,
+the mocked payment request/status flow, and the Playwright browser suite. The
+mock transport is selected only when `BLUEM_ACCEPTANCE_MOCK_URL` is set, so the
+normal plugin path remains unchanged and no Bluem hostname is contacted.
+
+The seeded fixture includes a product, pending order, linked Bluem payment
+request, and iDEAL gateway settings. The broad flow covers plugin deactivate /
+reactivate, admin and settings pages, WooCommerce activation and gateway
+registration, settings persistence, the order Bluem request metabox, the
+transaction detail page, payment request creation, mocked status retrieval,
+request persistence, and the resulting order transition to processing.
+
 ## Docker preparation and translation test
 
 The Docker Compose setup includes a WP-CLI service. The preparation target

--- a/docs/acceptance-testing-plan.md
+++ b/docs/acceptance-testing-plan.md
@@ -253,6 +253,19 @@ The CI job installs Chromium, runs `npm run test:e2e`, and uploads Playwright
 traces, screenshots, and reports when available. The browser layer does not
 install WordPress or prepare sample data.
 
+## Full isolated E2E CI job
+
+The complete `make acceptance_e2e_test` flow also runs in its own
+`acceptance-e2e` CI job. This is intentionally separate from the lightweight
+browser job: it prepares WooCommerce fixtures, starts the local Bluem mock,
+exercises the Codeception HTTP flow and the Playwright admin flow, and has a
+longer timeout and dedicated Docker/Codeception/Playwright diagnostics.
+
+The job has no Bluem credentials and sets the mock transport endpoint only for
+the test environment. It does not contact Bluem or create billable requests.
+Keeping it as a separate job gives pull requests broad regression protection
+without coupling the PHP unit matrix to Docker lifecycle or browser failures.
+
 Equivalent local commands:
 
 ```make

--- a/docs/acceptance-testing-plan.md
+++ b/docs/acceptance-testing-plan.md
@@ -45,6 +45,12 @@ registration, settings persistence, the order Bluem request metabox, the
 transaction detail page, payment request creation, mocked status retrieval,
 request persistence, and the resulting order transition to processing.
 
+The browser lifecycle test also completes the local Bluem activation form
+after reactivation because the plugin intentionally resets its setup guard on
+activation. The passing local run produced 8 Codeception tests with 18
+assertions, a mocked callback that returned HTTP 302 and moved the fixture
+order to `processing`, and 4 passing Chromium tests.
+
 ## Docker preparation and translation test
 
 The Docker Compose setup includes a WP-CLI service. The preparation target

--- a/docs/acceptance-testing-plan.md
+++ b/docs/acceptance-testing-plan.md
@@ -53,6 +53,13 @@ The flow also exercises a mocked `Pending` callback and verifies that it keeps
 the order pending while persisting the in-progress request status. The browser
 transaction test opens the detail page and verifies the persisted transaction.
 
+The expanded flow also enables the mandate and iDIN modules for a separate
+non-checkout pass. It creates an eMandate through the WooCommerce mandate
+gateway, calls the mocked `SRX` status callback, and verifies the request row
+and order transition. It renders the `[bluem_identificatieformulier]` shortcode,
+creates an iDIN request through the shortcode entry point, calls the mocked
+`ISX` callback, and verifies the identity request reaches `Success`.
+
 The browser lifecycle test also completes the local Bluem activation form
 after reactivation because the plugin intentionally resets its setup guard on
 activation. The passing local run produced 8 Codeception tests with 18

--- a/docs/e2e-testing-findings.md
+++ b/docs/e2e-testing-findings.md
@@ -1,0 +1,16 @@
+# E2E testing findings
+
+This log captures plugin or library defects exposed while extending the local
+WordPress/WooCommerce acceptance suite. Record a finding here instead of
+weakening a test to accommodate faulty production behavior.
+
+## 2026-08-15: legacy WooCommerce order editor omitted Bluem requests
+
+The order-request metabox was registered only on WooCommerce's HPOS screen
+(`woocommerce_page_wc-orders`). Stores using the legacy post-based order editor
+therefore could not inspect linked Bluem requests from an order page.
+
+Status: fixed in PR #69 by registering the same metabox on `shop_order` and by
+accepting either a `WC_Order` or `WP_Post` in its renderer. Browser acceptance
+coverage exercises the legacy editor; the existing HPOS integration suite
+continues to cover query behavior under custom order tables.

--- a/docs/e2e-testing-findings.md
+++ b/docs/e2e-testing-findings.md
@@ -10,7 +10,8 @@ The order-request metabox was registered only on WooCommerce's HPOS screen
 (`woocommerce_page_wc-orders`). Stores using the legacy post-based order editor
 therefore could not inspect linked Bluem requests from an order page.
 
-Status: fixed in PR #69 by registering the same metabox on `shop_order` and by
-accepting either a `WC_Order` or `WP_Post` in its renderer. Browser acceptance
-coverage exercises the legacy editor; the existing HPOS integration suite
-continues to cover query behavior under custom order tables.
+Status: fixed in PR #69 by registering the same metabox through WordPress's
+legacy `shop_order` hook and by accepting either a `WC_Order` or `WP_Post` in
+its renderer. Browser acceptance coverage exercises the legacy editor; the
+existing HPOS integration suite continues to cover query behavior under custom
+order tables.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -30,6 +30,26 @@ Follow-up:
 
 Relevant code: `bluem.php`, `bluem_update_request_by_id()`.
 
+## iDIN shortcode callback URL relies on canonical slash redirect
+
+Status: observed during isolated testing; assess separately.
+
+The iDIN shortcode entry point generates a callback URL without a trailing
+slash. In the Docker WordPress environment, the corresponding rewrite route
+responds with a canonical 301 before the callback handler runs. The acceptance
+flow uses the canonical slash form so it tests the handler itself.
+
+Follow-up:
+
+- Confirm that Bluem follows the redirect for all iDIN callback flows.
+- Consider generating the canonical URL directly with `user_trailingslashit()`
+  or an equivalent WordPress URL helper.
+- Add a regression test for the externally generated callback URL if the
+  redirect is not guaranteed by the provider.
+
+Relevant code: `bluem_idin_execute()` and
+`bluem_get_idin_shortcode_callback_url()`.
+
 ## Plugin reactivation resets configuration state
 
 Status: observed in the Docker browser flow; intentionality is unclear.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,58 @@
+# Known issues discovered during testing
+
+This document records defects or suspicious behavior found while extending the
+isolated WordPress/WooCommerce acceptance flow. These items are deliberately
+kept separate from the regression tests: a test may reproduce an issue, but it
+must not normalize or hide incorrect plugin behavior.
+
+## Admin status refresh can fail in-progress payment states
+
+Status: confirmed by code review; needs a focused regression test and fix.
+
+Evidence:
+
+- `bluem_update_request_by_id()` calls `PaymentStatus()` for payment requests.
+- Its payment branch handles `Success`, `Cancelled`, and `Expired` explicitly.
+- `Pending`, `Open`, `New`, and every other status fall into the final `else`
+  branch, which marks the WooCommerce order as `failed`.
+- The same shape exists in the mandate branch.
+- This conflicts with the documented Bluem lifecycle: `New`, `Open`, and
+  `Pending` are in-progress states and must not be treated as failures.
+
+Follow-up:
+
+- Add an HTTP/admin regression case with mocked `Pending`, `Open`, and `New`
+  status responses.
+- Make the admin refresh persist the request status while leaving the order
+  pending/in progress for those states.
+- Confirm the intended semantics for `SuccessManual`, `BankSelected`, and
+  `Refunded` before changing their order behavior.
+
+Relevant code: `bluem.php`, `bluem_update_request_by_id()`.
+
+## Plugin reactivation resets configuration state
+
+Status: observed in the Docker browser flow; intentionality is unclear.
+
+Reactivating Bluem resets its setup/registration state and can remove required
+configuration such as mandate identifiers. The acceptance flow must complete
+the activation form again before normal admin pages are usable. This may be
+intentional for first-run setup, but resetting existing merchant configuration
+on a deactivate/reactivate cycle deserves a product decision and a dedicated
+regression test.
+
+Follow-up:
+
+- Determine whether deactivation/reactivation is expected to preserve settings.
+- If settings should survive, add an activation-hook regression test and fix
+  the reset behavior.
+- If the reset is intentional, make the behavior explicit in the UI and
+  document which values are cleared.
+
+## Library issues
+
+No independent defect in `vendor/bluem-development/bluem-php` was established
+by the current acceptance work. The local Bluem mock still exercises the real
+library request construction, configuration validation, response parsing, and
+plugin order-transition code. Any future library defect should be recorded here
+with the library version, request/response fixture, and a minimal reproduction.

--- a/gateways/Bluem_Mandates_Payment_Gateway.php
+++ b/gateways/Bluem_Mandates_Payment_Gateway.php
@@ -382,7 +382,7 @@ class Bluem_Mandates_Payment_Gateway extends Bluem_Payment_Gateway
         }
 
         try {
-            $this->bluem = new Bluem($this->bluem_config);
+            $this->bluem = bluem_woocommerce_create_client($this->bluem_config);
         } catch (Exception $e) {
             return [
                 'exception' => $e->getMessage(),

--- a/gateways/Bluem_Payment_Gateway.php
+++ b/gateways/Bluem_Payment_Gateway.php
@@ -202,7 +202,7 @@ abstract class Bluem_Payment_Gateway extends WC_Payment_Gateway implements Bluem
     protected function validateAndEnableBluemConfiguration(): bool
     {
         try {
-            $this->bluem = new Bluem($this->bluem_config);
+            $this->bluem = bluem_woocommerce_create_client($this->bluem_config);
         } catch (Exception $e) {
             return false;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "bluem-woocommerce-browser-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bluem-woocommerce-browser-tests",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests/playwright',
+  fullyParallel: false,
+  workers: 1,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',

--- a/scripts/acceptance-prepare-advanced-fixtures.php
+++ b/scripts/acceptance-prepare-advanced-fixtures.php
@@ -1,0 +1,46 @@
+<?php
+
+if (!defined('WP_CLI') || !WP_CLI) {
+    return;
+}
+
+$options = get_option('bluem_woocommerce_options', []);
+$options = array_merge($options, [
+    'environment' => 'test',
+    'senderID' => 'S0001',
+    'test_accessToken' => 'ci-acceptance-token',
+    'production_accessToken' => 'ci-acceptance-production-token',
+    'expectedReturnStatus' => 'success',
+    'suppress_woo' => '0',
+    'payments_enabled' => '1',
+    'mandates_enabled' => '1',
+    'idin_enabled' => '1',
+    'brandID' => 'AcceptanceMandateBrand',
+    'merchantID' => 'AcceptanceMerchant',
+    'merchantSubId' => '0',
+    'eMandateReason' => 'Bluem acceptance mandate',
+    'localInstrumentCode' => 'CORE',
+    'requestType' => 'Issuing',
+    'sequenceType' => 'RCUR',
+    'IDINBrandID' => 'AcceptanceIdentityBrand',
+    'IDINPageURL' => 'my-account',
+    'IDINShortcodeOnlyAfterLogin' => '0',
+    'IDINDescription' => 'Identity acceptance {gebruikersnaam}',
+    'idin_request_name' => '1',
+    'idin_request_address' => '1',
+    'idin_request_birthdate' => '1',
+    'idin_request_gender' => '0',
+    'idin_request_telephone' => '1',
+    'idin_request_email' => '1',
+    'paymentsIDEALBrandID' => 'Payment',
+]);
+
+update_option('bluem_woocommerce_options', $options, false);
+
+update_option('woocommerce_bluem_mandates_settings', [
+    'enabled' => 'yes',
+    'title' => 'Bluem eMandate Acceptance',
+    'description' => 'Isolated acceptance mandate method',
+], false);
+
+WP_CLI::success('Mandate and iDIN acceptance modules are configured with isolated fixture values.');

--- a/scripts/acceptance-prepare-fixtures.php
+++ b/scripts/acceptance-prepare-fixtures.php
@@ -1,0 +1,99 @@
+<?php
+
+if (!defined('WP_CLI') || !WP_CLI) {
+    return;
+}
+
+if (!class_exists('WooCommerce')) {
+    WP_CLI::error('WooCommerce must be active before creating acceptance fixtures.');
+}
+
+$admin = get_user_by('login', getenv('WP_ACCEPTANCE_ADMIN_USER') ?: 'wordpress');
+if (!$admin) {
+    WP_CLI::error('The acceptance administrator could not be found.');
+}
+
+$product = null;
+$productId = (int) get_option('bluem_acceptance_fixture_product_id', 0);
+if ($productId > 0) {
+    $product = wc_get_product($productId);
+}
+
+if (!$product) {
+    $product = new WC_Product_Simple();
+    $product->set_name('Bluem Acceptance Fixture Product');
+    $product->set_status('publish');
+    $product->set_catalog_visibility('visible');
+    $product->set_regular_price('12.34');
+    $product->set_price('12.34');
+    $product->set_sku('bluem-acceptance-fixture');
+    $product->save();
+    update_option('bluem_acceptance_fixture_product_id', $product->get_id(), false);
+}
+
+$order = null;
+$orderId = (int) get_option('bluem_acceptance_fixture_order_id', 0);
+if ($orderId > 0) {
+    $order = wc_get_order($orderId);
+}
+
+if (!$order) {
+    $order = wc_create_order(['customer_id' => $admin->ID]);
+    $order->set_created_via('bluem-acceptance');
+    $order->set_customer_id($admin->ID);
+    $order->set_billing_first_name('Bluem');
+    $order->set_billing_last_name('Acceptance');
+    $order->set_billing_email('bluem-acceptance@example.com');
+    $order->set_billing_country('NL');
+    $order->add_product($product, 1);
+    $order->set_payment_method('bluem_payments_ideal');
+    $order->set_payment_method_title('Bluem iDEAL (Acceptance)');
+    $order->calculate_totals();
+    $order->update_status('pending', 'Acceptance fixture order');
+    $order->save();
+    update_option('bluem_acceptance_fixture_order_id', $order->get_id(), false);
+}
+
+$order->update_status('pending', 'Acceptance fixture order');
+$order->set_payment_method('bluem_payments_ideal');
+$order->save();
+
+update_option(
+    'woocommerce_bluem_payments_ideal_settings',
+    [
+        'enabled' => 'yes',
+        'title' => 'Bluem iDEAL Acceptance',
+        'description' => 'Isolated acceptance payment method',
+        'paymentsIDEALBrandID' => 'Payment',
+    ],
+    false
+);
+
+$requestId = (int) get_option('bluem_acceptance_fixture_request_id', 0);
+$request = $requestId > 0 ? bluem_db_get_request_by_id((string) $requestId) : false;
+if (!$request) {
+    $requestId = bluem_db_create_request([
+        'entrance_code' => 'ACCEPTANCE-ENTRANCE-1',
+        'transaction_id' => 'ACCEPTANCE-TRANSACTION-1',
+        'transaction_url' => 'https://mock-bluem.invalid/payment/transaction/ACCEPTANCE-TRANSACTION-1',
+        'user_id' => $admin->ID,
+        'timestamp' => gmdate('Y-m-d H:i:s'),
+        'description' => 'Bluem acceptance fixture payment',
+        'debtor_reference' => (string) $order->get_id(),
+        'type' => 'ideal',
+        'order_id' => $order->get_id(),
+        'payload' => wp_json_encode([
+            'environment' => 'test',
+            'amount' => $order->get_total(),
+            'method' => 'Payment',
+            'currency' => $order->get_currency(),
+        ]),
+    ]);
+    update_option('bluem_acceptance_fixture_request_id', $requestId, false);
+} else {
+    bluem_db_update_request($request->id, ['status' => 'created']);
+}
+
+WP_CLI::log(sprintf('Acceptance fixture order: %d', $order->get_id()));
+WP_CLI::log(sprintf('Acceptance fixture request: %d', $requestId));
+WP_CLI::success('WooCommerce and Bluem acceptance fixtures are ready.');

--- a/scripts/acceptance-prepare-fixtures.php
+++ b/scripts/acceptance-prepare-fixtures.php
@@ -69,13 +69,17 @@ update_option(
     false
 );
 
+$bluemOptions = get_option('bluem_woocommerce_options', []);
+$bluemOptions['paymentsIDEALBrandID'] = 'Payment';
+update_option('bluem_woocommerce_options', $bluemOptions, false);
+
 $requestId = (int) get_option('bluem_acceptance_fixture_request_id', 0);
 $request = $requestId > 0 ? bluem_db_get_request_by_id((string) $requestId) : false;
 if (!$request) {
     $requestId = bluem_db_create_request([
-        'entrance_code' => 'ACCEPTANCE-ENTRANCE-1',
-        'transaction_id' => 'ACCEPTANCE-TRANSACTION-1',
-        'transaction_url' => 'https://mock-bluem.invalid/payment/transaction/ACCEPTANCE-TRANSACTION-1',
+        'entrance_code' => 'ACCEPTANCEENTRANCE1',
+        'transaction_id' => 'ACCEPTANCETX1',
+        'transaction_url' => 'https://mock-bluem.invalid/payment/transaction/ACCEPTANCETX1',
         'user_id' => $admin->ID,
         'timestamp' => gmdate('Y-m-d H:i:s'),
         'description' => 'Bluem acceptance fixture payment',
@@ -91,7 +95,12 @@ if (!$request) {
     ]);
     update_option('bluem_acceptance_fixture_request_id', $requestId, false);
 } else {
-    bluem_db_update_request($request->id, ['status' => 'created']);
+    bluem_db_update_request($request->id, [
+        'entrance_code' => 'ACCEPTANCEENTRANCE1',
+        'transaction_id' => 'ACCEPTANCETX1',
+        'transaction_url' => 'https://mock-bluem.invalid/payment/transaction/ACCEPTANCETX1',
+        'status' => 'created',
+    ]);
 }
 
 WP_CLI::log(sprintf('Acceptance fixture order: %d', $order->get_id()));

--- a/scripts/acceptance-prepare-woocommerce.sh
+++ b/scripts/acceptance-prepare-woocommerce.sh
@@ -12,7 +12,7 @@ if ! wpcli plugin is-installed woocommerce >/dev/null 2>&1; then
     wpcli plugin install woocommerce --version="$woocommerce_version"
 fi
 wpcli plugin activate woocommerce
-wpcli option update bluem_woocommerce_options '{"environment":"test","senderID":"ci-acceptance-sender","test_accessToken":"ci-acceptance-token","production_accessToken":"ci-acceptance-production-token","expectedReturnStatus":"success","suppress_woo":"1","suppress_warning":"1","payments_enabled":"1","mandates_enabled":"1","idin_enabled":"1"}' --format=json
+wpcli option update bluem_woocommerce_options '{"environment":"test","senderID":"S0001","test_accessToken":"ci-acceptance-token","production_accessToken":"ci-acceptance-production-token","expectedReturnStatus":"success","suppress_woo":"1","suppress_warning":"1","payments_enabled":"1","mandates_enabled":"1","idin_enabled":"1","paymentsIDEALBrandID":"Payment"}' --format=json
 wpcli option update bluem_plugin_registration 1
 wpcli plugin activate bluem
 wpcli eval-file /opt/bluem-scripts/acceptance-prepare-fixtures.php

--- a/scripts/acceptance-prepare-woocommerce.sh
+++ b/scripts/acceptance-prepare-woocommerce.sh
@@ -15,3 +15,4 @@ wpcli plugin activate woocommerce
 wpcli option update bluem_woocommerce_options '{"environment":"test","senderID":"ci-acceptance-sender","test_accessToken":"ci-acceptance-token","production_accessToken":"ci-acceptance-production-token","expectedReturnStatus":"success","suppress_woo":"1","suppress_warning":"1","payments_enabled":"1","mandates_enabled":"1","idin_enabled":"1"}' --format=json
 wpcli option update bluem_plugin_registration 1
 wpcli plugin activate bluem
+wpcli eval-file /opt/bluem-scripts/acceptance-prepare-fixtures.php

--- a/scripts/acceptance-prepare.sh
+++ b/scripts/acceptance-prepare.sh
@@ -47,6 +47,10 @@ fi
 wpcli language core install en_US
 wpcli site switch-language en_US
 wpcli language core install nl_NL
+# Bluem's WooCommerce callback endpoints use pretty URLs under /wc-api/.
+# A fresh WordPress installation defaults to the Plain permalink structure,
+# which routes those callback URLs to the front page instead of the gateway.
+wpcli rewrite structure '/%postname%/' --hard
 wpcli plugin activate bluem
 wpcli plugin is-active bluem
 

--- a/scripts/acceptance-prepare.sh
+++ b/scripts/acceptance-prepare.sh
@@ -52,5 +52,5 @@ wpcli plugin is-active bluem
 
 # Complete the plugin's setup guard with isolated, non-production values so
 # acceptance tests do not require manual activation-form submission.
-wpcli option update bluem_woocommerce_options '{"environment":"test","senderID":"ci-acceptance-sender","test_accessToken":"ci-acceptance-token","production_accessToken":"ci-acceptance-production-token","expectedReturnStatus":"success","suppress_woo":"1","suppress_warning":"1","payments_enabled":"0","mandates_enabled":"0","idin_enabled":"0"}' --format=json
+wpcli option update bluem_woocommerce_options '{"environment":"test","senderID":"S0001","test_accessToken":"ci-acceptance-token","production_accessToken":"ci-acceptance-production-token","expectedReturnStatus":"success","suppress_woo":"1","suppress_warning":"1","payments_enabled":"0","mandates_enabled":"0","idin_enabled":"0"}' --format=json
 wpcli option update bluem_plugin_registration 1

--- a/scripts/acceptance-test-gateways.php
+++ b/scripts/acceptance-test-gateways.php
@@ -47,4 +47,9 @@ if (!str_contains($idin_shortcode, 'bluem-woocommerce-button-idin')) {
     WP_CLI::error('The Bluem iDIN shortcode did not render its form.');
 }
 
-WP_CLI::success('Classic and Blocks gateways plus mandate and iDIN shortcodes are registered and render.');
+$idealSettings = get_option('woocommerce_bluem_payments_ideal_settings', []);
+if (($idealSettings['enabled'] ?? '') !== 'yes' || ($idealSettings['title'] ?? '') !== 'Bluem iDEAL Acceptance') {
+    WP_CLI::error('Bluem iDEAL acceptance settings were not persisted.');
+}
+
+WP_CLI::success('Classic and Blocks gateways plus mandate and iDIN shortcodes are registered, and iDEAL settings persist.');

--- a/scripts/acceptance-test-identity-flow.php
+++ b/scripts/acceptance-test-identity-flow.php
@@ -1,0 +1,44 @@
+<?php
+
+if (!defined('WP_CLI') || !WP_CLI || !function_exists('do_shortcode')) {
+    WP_CLI::error('WordPress must be loaded before running the iDIN acceptance test.');
+}
+
+$admin = get_user_by('login', getenv('WP_ACCEPTANCE_ADMIN_USER') ?: 'wordpress');
+if (!$admin) {
+    WP_CLI::error('The acceptance administrator could not be found.');
+}
+wp_set_current_user($admin->ID);
+
+$shortcode = do_shortcode('[bluem_identificatieformulier]');
+if (!str_contains($shortcode, 'bluem-woocommerce-button-idin')) {
+    WP_CLI::error('The iDIN shortcode did not render its entry form.');
+}
+
+$result = bluem_idin_execute(null, false, false);
+if (!is_array($result) || ($result['result'] ?? false) !== true) {
+    WP_CLI::error('iDIN request creation failed: ' . wp_json_encode($result));
+}
+
+$request = bluem_db_get_request_by_transaction_id('ACCEPTANCEIDINTX1');
+if (!$request || $request->type !== 'identity') {
+    WP_CLI::error('iDIN request was not persisted in the Bluem request table.');
+}
+
+$callback_url = home_url('bluem-woocommerce/idin_shortcode_callback/?debtorReference=' . rawurlencode((string)$request->debtor_reference));
+$callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
+$callback_response = wp_remote_get($callback_url, [
+    'timeout' => 15,
+    'redirection' => 0,
+    'headers' => ['Host' => 'localhost:8000'],
+]);
+if (is_wp_error($callback_response)) {
+    WP_CLI::error('Mocked iDIN callback request failed: ' . $callback_response->get_error_message());
+}
+
+$request = bluem_db_get_request_by_id((string)$request->id);
+if (!$request || $request->status !== 'Success') {
+    WP_CLI::error('iDIN callback did not persist Success status.');
+}
+
+WP_CLI::success('Bluem iDIN flow passed: shortcode rendered, identity request created, and callback persisted Success.');

--- a/scripts/acceptance-test-in-progress-flow.php
+++ b/scripts/acceptance-test-in-progress-flow.php
@@ -26,7 +26,7 @@ bluem_db_update_request($request_id, [
     'status' => 'created',
 ]);
 
-$callback_url = home_url('wc-api/bluem_payments_ideal_callback?entranceCode=ACCEPTANCEPENDINGENTRANCE');
+$callback_url = home_url('wc-api/bluem_payments_ideal_callback/?entranceCode=ACCEPTANCEPENDINGENTRANCE');
 $callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
 $callback_response = wp_remote_get($callback_url, [
     'timeout' => 15,

--- a/scripts/acceptance-test-in-progress-flow.php
+++ b/scripts/acceptance-test-in-progress-flow.php
@@ -1,0 +1,50 @@
+<?php
+
+if (! defined('WP_CLI') || ! WP_CLI || ! function_exists('wc_get_order')) {
+    WP_CLI::error('WooCommerce must be active before running the in-progress acceptance test.');
+}
+
+$order_id = (int) get_option('bluem_acceptance_fixture_order_id', 0);
+$order = wc_get_order($order_id);
+if (! $order) {
+    WP_CLI::error('The acceptance fixture order could not be found.');
+}
+
+$order->update_status('pending', 'Reset by Bluem in-progress acceptance test');
+$order->update_meta_data('bluem_transactionid', 'ACCEPTANCEPENDING1');
+$order->update_meta_data('bluem_entrancecode', 'ACCEPTANCEPENDINGENTRANCE');
+$order->save();
+
+$request_id = (int) get_option('bluem_acceptance_fixture_request_id', 0);
+if ($request_id <= 0 || ! bluem_db_get_request_by_id((string) $request_id)) {
+    WP_CLI::error('The acceptance fixture request could not be found.');
+}
+
+bluem_db_update_request($request_id, [
+    'entrance_code' => 'ACCEPTANCEPENDINGENTRANCE',
+    'transaction_id' => 'ACCEPTANCEPENDING1',
+    'status' => 'created',
+]);
+
+$callback_url = home_url('wc-api/bluem_payments_ideal_callback?entranceCode=ACCEPTANCEPENDINGENTRANCE');
+$callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
+$callback_response = wp_remote_get($callback_url, [
+    'timeout' => 15,
+    'redirection' => 0,
+    'headers' => ['Host' => 'localhost:8000'],
+]);
+if (is_wp_error($callback_response)) {
+    WP_CLI::error('Mocked in-progress callback request failed: ' . $callback_response->get_error_message());
+}
+
+$order = wc_get_order($order_id);
+$request = bluem_db_get_request_by_id((string) $request_id);
+if ($order->get_status() !== 'pending' || ! $request || $request->status !== 'Pending') {
+    WP_CLI::error(sprintf(
+        'Pending callback changed state unexpectedly: order=%s request=%s.',
+        $order->get_status(),
+        $request->status ?? 'missing'
+    ));
+}
+
+WP_CLI::success('Bluem Pending callback kept the order pending and persisted the in-progress status.');

--- a/scripts/acceptance-test-mandate-flow.php
+++ b/scripts/acceptance-test-mandate-flow.php
@@ -41,7 +41,7 @@ if (!$request) {
     WP_CLI::error('Mandate request was not persisted in the Bluem request table.');
 }
 
-$callback_url = home_url('wc-api/bluem_mandates_callback?mandateID=' . rawurlencode($mandate_id));
+$callback_url = home_url('wc-api/bluem_mandates_callback/?mandateID=' . rawurlencode($mandate_id));
 $callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
 $callback_response = wp_remote_get($callback_url, [
     'timeout' => 15,

--- a/scripts/acceptance-test-mandate-flow.php
+++ b/scripts/acceptance-test-mandate-flow.php
@@ -1,0 +1,65 @@
+<?php
+
+if (!defined('WP_CLI') || !WP_CLI || !function_exists('wc_get_order')) {
+    WP_CLI::error('WooCommerce must be active before running the mandate acceptance test.');
+}
+
+$admin = get_user_by('login', getenv('WP_ACCEPTANCE_ADMIN_USER') ?: 'wordpress');
+if (!$admin) {
+    WP_CLI::error('The acceptance administrator could not be found.');
+}
+wp_set_current_user($admin->ID);
+
+$order_id = (int)get_option('bluem_acceptance_fixture_order_id', 0);
+$order = wc_get_order($order_id);
+if (!$order) {
+    WP_CLI::error('The acceptance fixture order could not be found.');
+}
+
+$order->update_status('pending', 'Reset by Bluem mandate acceptance test');
+$order->set_payment_method('bluem_mandates');
+$order->save();
+
+if (!class_exists('Bluem_Mandates_Payment_Gateway')) {
+    WP_CLI::error('The Bluem mandate gateway was not loaded.');
+}
+
+$gateway = new Bluem_Mandates_Payment_Gateway();
+$result = $gateway->process_payment($order_id);
+if (!is_array($result) || ($result['result'] ?? '') !== 'success') {
+    WP_CLI::error('Mandate request creation failed: ' . wp_json_encode($result));
+}
+
+$order = wc_get_order($order_id);
+$mandate_id = (string)$order->get_meta('bluem_mandateid');
+if ($mandate_id === '') {
+    WP_CLI::error('Mandate request did not persist a mandate ID.');
+}
+
+$request = bluem_db_get_request_by_transaction_id_and_type($mandate_id, 'mandates');
+if (!$request) {
+    WP_CLI::error('Mandate request was not persisted in the Bluem request table.');
+}
+
+$callback_url = home_url('wc-api/bluem_mandates_callback?mandateID=' . rawurlencode($mandate_id));
+$callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
+$callback_response = wp_remote_get($callback_url, [
+    'timeout' => 15,
+    'redirection' => 0,
+    'headers' => ['Host' => 'localhost:8000'],
+]);
+if (is_wp_error($callback_response)) {
+    WP_CLI::error('Mocked mandate callback request failed: ' . $callback_response->get_error_message());
+}
+
+$order = wc_get_order($order_id);
+$request = bluem_db_get_request_by_id((string)$request->id);
+if ($order->get_status() !== 'processing' || !$request || $request->status !== 'Success') {
+    WP_CLI::error(sprintf(
+        'Mandate callback did not complete: order=%s request=%s.',
+        $order->get_status(),
+        $request->status ?? 'missing'
+    ));
+}
+
+WP_CLI::success(sprintf('Bluem mandate flow passed: mandate %s, order %d, final status processing.', $mandate_id, $order_id));

--- a/scripts/acceptance-test-request-flow.php
+++ b/scripts/acceptance-test-request-flow.php
@@ -1,10 +1,17 @@
 <?php
 
-declare(strict_types=1);
-
 if (! defined('WP_CLI') || ! WP_CLI || ! function_exists('wc_get_order')) {
     WP_CLI::error('WooCommerce must be active before running the request-flow acceptance test.');
 }
+
+$bluemOptions = get_option('bluem_woocommerce_options', []);
+$bluemOptions['environment'] = 'test';
+$bluemOptions['senderID'] = 'S0001';
+$bluemOptions['test_accessToken'] = 'ci-acceptance-token';
+$bluemOptions['production_accessToken'] = 'ci-acceptance-production-token';
+$bluemOptions['payments_enabled'] = '1';
+$bluemOptions['paymentsIDEALBrandID'] = 'Payment';
+update_option('bluem_woocommerce_options', $bluemOptions, false);
 
 $order_id = (int) get_option('bluem_acceptance_fixture_order_id', 0);
 $order = wc_get_order($order_id);
@@ -17,8 +24,7 @@ $order->delete_meta_data('bluem_transactionid');
 $order->delete_meta_data('bluem_entrancecode');
 $order->save();
 
-$gateways = WC()->payment_gateways()->payment_gateways();
-$gateway = $gateways['bluem_payments_ideal'] ?? null;
+$gateway = new Bluem_iDEAL_Payment_Gateway();
 if (! $gateway instanceof Bluem_Payment_Gateway) {
     WP_CLI::error('The Bluem iDEAL gateway is not available.');
 }
@@ -40,12 +46,20 @@ if ($transaction_id === '' || $entrance_code === '' || ! $request) {
 
 $callback_url = home_url('wc-api/bluem_payments_ideal_callback?entranceCode=' . rawurlencode($entrance_code));
 $callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
-$callback_response = wp_remote_get($callback_url, ['timeout' => 15]);
+$callback_response = wp_remote_get($callback_url, [
+    'timeout' => 15,
+    'redirection' => 0,
+    'headers' => ['Host' => 'localhost:8000'],
+]);
 if (is_wp_error($callback_response)) {
     WP_CLI::error('Mocked Bluem callback request failed: ' . $callback_response->get_error_message());
 }
 
-$order = wc_get_order($order->get_id());
+WP_CLI::log('Callback HTTP status: ' . wp_remote_retrieve_response_code($callback_response));
+WP_CLI::log('Callback location: ' . (wp_remote_retrieve_header($callback_response, 'location') ?: ''));
+WP_CLI::log('Callback response: ' . wp_strip_all_tags(wp_remote_retrieve_body($callback_response)));
+
+$order = new WC_Order($order->get_id());
 if ($order->get_status() !== 'processing') {
     WP_CLI::error('Mocked Bluem Success callback did not move the order to processing. Status: ' . $order->get_status());
 }

--- a/scripts/acceptance-test-request-flow.php
+++ b/scripts/acceptance-test-request-flow.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+if (! defined('WP_CLI') || ! WP_CLI || ! function_exists('wc_get_order')) {
+    WP_CLI::error('WooCommerce must be active before running the request-flow acceptance test.');
+}
+
+$order_id = (int) get_option('bluem_acceptance_fixture_order_id', 0);
+$order = wc_get_order($order_id);
+if (! $order) {
+    WP_CLI::error('The acceptance fixture order could not be found.');
+}
+
+$order->update_status('pending', 'Reset by Bluem request-flow acceptance test');
+$order->delete_meta_data('bluem_transactionid');
+$order->delete_meta_data('bluem_entrancecode');
+$order->save();
+
+$gateways = WC()->payment_gateways()->payment_gateways();
+$gateway = $gateways['bluem_payments_ideal'] ?? null;
+if (! $gateway instanceof Bluem_Payment_Gateway) {
+    WP_CLI::error('The Bluem iDEAL gateway is not available.');
+}
+
+$_POST = [];
+$result = $gateway->process_payment($order->get_id());
+if (($result['result'] ?? '') !== 'success') {
+    WP_CLI::error('Mocked Bluem payment creation failed: ' . wp_json_encode($result));
+}
+
+$order = wc_get_order($order->get_id());
+$transaction_id = (string) $order->get_meta('bluem_transactionid', true);
+$entrance_code = (string) $order->get_meta('bluem_entrancecode', true);
+$request = $transaction_id !== '' ? bluem_db_get_request_by_transaction_id($transaction_id) : false;
+
+if ($transaction_id === '' || $entrance_code === '' || ! $request) {
+    WP_CLI::error('Mocked Bluem payment did not persist transaction correlation data.');
+}
+
+$callback_url = home_url('wc-api/bluem_payments_ideal_callback?entranceCode=' . rawurlencode($entrance_code));
+$callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
+$callback_response = wp_remote_get($callback_url, ['timeout' => 15]);
+if (is_wp_error($callback_response)) {
+    WP_CLI::error('Mocked Bluem callback request failed: ' . $callback_response->get_error_message());
+}
+
+$order = wc_get_order($order->get_id());
+if ($order->get_status() !== 'processing') {
+    WP_CLI::error('Mocked Bluem Success callback did not move the order to processing. Status: ' . $order->get_status());
+}
+
+$request = bluem_db_get_request_by_transaction_id($transaction_id);
+if (! $request || $request->status !== 'Success') {
+    WP_CLI::error('Mocked Bluem Success callback did not persist the request status.');
+}
+
+WP_CLI::success(sprintf(
+    'Bluem request flow passed: transaction %s, order %d, final status %s.',
+    $transaction_id,
+    $order->get_id(),
+    $order->get_status()
+));

--- a/scripts/acceptance-test-request-flow.php
+++ b/scripts/acceptance-test-request-flow.php
@@ -44,7 +44,7 @@ if ($transaction_id === '' || $entrance_code === '' || ! $request) {
     WP_CLI::error('Mocked Bluem payment did not persist transaction correlation data.');
 }
 
-$callback_url = home_url('wc-api/bluem_payments_ideal_callback?entranceCode=' . rawurlencode($entrance_code));
+$callback_url = home_url('wc-api/bluem_payments_ideal_callback/?entranceCode=' . rawurlencode($entrance_code));
 $callback_url = str_replace('http://localhost:8000', 'http://wordpress', $callback_url);
 $callback_response = wp_remote_get($callback_url, [
     'timeout' => 15,

--- a/scripts/acceptance-test-request-flow.php
+++ b/scripts/acceptance-test-request-flow.php
@@ -59,7 +59,17 @@ WP_CLI::log('Callback HTTP status: ' . wp_remote_retrieve_response_code($callbac
 WP_CLI::log('Callback location: ' . (wp_remote_retrieve_header($callback_response, 'location') ?: ''));
 WP_CLI::log('Callback response: ' . wp_strip_all_tags(wp_remote_retrieve_body($callback_response)));
 
-$order = new WC_Order($order->get_id());
+$order_id = $order->get_id();
+// The callback runs in the WordPress container while this WP-CLI process has
+// already cached the pending order. Clear those local caches before asserting
+// the database state written by the callback.
+clean_post_cache($order_id);
+if (class_exists('Automattic\\WooCommerce\\Caches\\OrderCache')) {
+    wc_get_container()
+        ->get(Automattic\WooCommerce\Caches\OrderCache::class)
+        ->remove($order_id);
+}
+$order = wc_get_order($order_id);
 $request = bluem_db_get_request_by_transaction_id($transaction_id);
 $order_notes = wc_get_order_notes([
     'order_id' => $order->get_id(),

--- a/scripts/acceptance-test-request-flow.php
+++ b/scripts/acceptance-test-request-flow.php
@@ -60,11 +60,24 @@ WP_CLI::log('Callback location: ' . (wp_remote_retrieve_header($callback_respons
 WP_CLI::log('Callback response: ' . wp_strip_all_tags(wp_remote_retrieve_body($callback_response)));
 
 $order = new WC_Order($order->get_id());
+$request = bluem_db_get_request_by_transaction_id($transaction_id);
+WP_CLI::log(sprintf(
+    'Callback persistence: order %d status %s; request status %s.',
+    $order->get_id(),
+    $order->get_status(),
+    $request->status ?? 'not found'
+));
 if ($order->get_status() !== 'processing') {
-    WP_CLI::error('Mocked Bluem Success callback did not move the order to processing. Status: ' . $order->get_status());
+    WP_CLI::error(sprintf(
+        'Mocked Bluem Success callback did not move order %d to processing. Order status: %s; request status: %s; transaction: %s; entrance code: %s.',
+        $order->get_id(),
+        $order->get_status(),
+        $request->status ?? 'not found',
+        $transaction_id,
+        $entrance_code
+    ));
 }
 
-$request = bluem_db_get_request_by_transaction_id($transaction_id);
 if (! $request || $request->status !== 'Success') {
     WP_CLI::error('Mocked Bluem Success callback did not persist the request status.');
 }

--- a/scripts/acceptance-test-request-flow.php
+++ b/scripts/acceptance-test-request-flow.php
@@ -61,11 +61,22 @@ WP_CLI::log('Callback response: ' . wp_strip_all_tags(wp_remote_retrieve_body($c
 
 $order = new WC_Order($order->get_id());
 $request = bluem_db_get_request_by_transaction_id($transaction_id);
+$order_notes = wc_get_order_notes([
+    'order_id' => $order->get_id(),
+    'limit' => 3,
+    'orderby' => 'date_created',
+    'order' => 'DESC',
+]);
+$recent_notes = array_map(
+    static fn ($note) => wp_strip_all_tags($note->content),
+    $order_notes
+);
 WP_CLI::log(sprintf(
-    'Callback persistence: order %d status %s; request status %s.',
+    'Callback persistence: order %d status %s; request status %s; recent notes: %s.',
     $order->get_id(),
     $order->get_status(),
-    $request->status ?? 'not found'
+    $request->status ?? 'not found',
+    $recent_notes ? implode(' | ', $recent_notes) : 'none'
 ));
 if ($order->get_status() !== 'processing') {
     WP_CLI::error(sprintf(

--- a/src/Testing/BluemAcceptanceHttpTransport.php
+++ b/src/Testing/BluemAcceptanceHttpTransport.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluem\Wordpress\Testing;
+
+use Bluem\BluemPHP\Transport\HttpTransportInterface;
+use Bluem\BluemPHP\Transport\HttpTransportResponse;
+use RuntimeException;
+
+/**
+ * Local-only transport for the Docker acceptance environment.
+ */
+final class BluemAcceptanceHttpTransport implements HttpTransportInterface
+{
+    public function __construct(private readonly string $endpoint)
+    {
+    }
+
+    public function send(string $url, array $headers, string $body): HttpTransportResponse
+    {
+        $curl = curl_init();
+
+        if ($curl === false) {
+            throw new RuntimeException('Unable to initialize acceptance mock transport');
+        }
+
+        curl_setopt_array($curl, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_URL => $this->endpoint,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_TIMEOUT => 10,
+        ]);
+
+        $response = curl_exec($curl);
+        $statusCode = (int) curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $errorMessage = curl_error($curl);
+        curl_close($curl);
+
+        if ($response === false) {
+            throw new RuntimeException($errorMessage !== '' ? $errorMessage : 'Acceptance mock request failed');
+        }
+
+        return new HttpTransportResponse($statusCode, (string) $response);
+    }
+}

--- a/tests/playwright/bluem-admin.spec.ts
+++ b/tests/playwright/bluem-admin.spec.ts
@@ -7,19 +7,21 @@ async function login(page: Page) {
   await page.locator('#wp-submit').click();
 }
 
-test('administrator can open Bluem settings and persist a change', async ({ page }) => {
+test('administrator can inspect the fixture order and Bluem transaction', async ({ page }) => {
   await login(page);
 
-  await page.goto('/wp-admin/admin.php?page=bluem-settings');
-  await expect(page.locator('h1')).toContainText('Settings');
-  await page.locator('a[data-tab="account"]').click();
-  await expect(page.locator('#bluem_woocommerce_settings_senderID')).toBeVisible();
-  await expect(page.locator('#bluem_woocommerce_settings_environment')).toBeVisible();
-  await page.locator('#bluem_woocommerce_settings_senderID').fill('playwright-acceptance-sender');
-  await page.locator('#bluem_woocommerce_settings_environment').selectOption('test');
-  await page.locator('input[name="submit"]').click();
-  await page.goto('/wp-admin/admin.php?page=bluem-settings');
-  await expect(page.locator('#bluem_woocommerce_settings_senderID')).toHaveValue('playwright-acceptance-sender');
+  const orderId = process.env.WP_ACCEPTANCE_FIXTURE_ORDER_ID;
+  const requestId = process.env.WP_ACCEPTANCE_FIXTURE_REQUEST_ID;
+  expect(orderId).toBeTruthy();
+  expect(requestId).toBeTruthy();
+
+  await page.goto(`/wp-admin/admin.php?page=wc-orders&action=edit&id=${orderId}`);
+  await expect(page.locator('body')).toContainText('Bluem request(s)');
+  await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
+
+  await page.goto(`/wp-admin/admin.php?page=bluem-transactions&request_id=${requestId}`);
+  await expect(page.locator('h1')).toContainText('Transaction details');
+  await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
 });
 
 test('administrator can deactivate and reactivate Bluem', async ({ page }) => {
@@ -33,8 +35,8 @@ test('administrator can deactivate and reactivate Bluem', async ({ page }) => {
   await pluginRow.getByRole('link', { name: 'Activate' }).click();
   await expect(pluginRow.getByRole('link', { name: 'Deactivate' })).toBeVisible();
 
-  // Activation resets Bluem's setup guard. Complete the local, non-production
-  // activation form so later browser tests can use normal admin pages.
+  // Activation resets Bluem's setup guard. Complete the local activation form
+  // so the plugin can continue serving normal admin pages.
   await page.goto('/wp-admin/admin.php?page=bluem-activate');
   await page.locator('#company_name').fill('Bluem Acceptance');
   await page.locator('#company_telephone').fill('0200000000');
@@ -53,19 +55,17 @@ test('administrator can open WooCommerce payment settings', async ({ page }) => 
   await expect(page.locator('body')).toContainText('Bluem payments via PayPal');
 });
 
-test('administrator can inspect the fixture order and Bluem transaction', async ({ page }) => {
+test('administrator can open Bluem settings and persist a change', async ({ page }) => {
   await login(page);
 
-  const orderId = process.env.WP_ACCEPTANCE_FIXTURE_ORDER_ID;
-  const requestId = process.env.WP_ACCEPTANCE_FIXTURE_REQUEST_ID;
-  expect(orderId).toBeTruthy();
-  expect(requestId).toBeTruthy();
-
-  await page.goto(`/wp-admin/admin.php?page=wc-orders&action=edit&id=${orderId}`);
-  await expect(page.locator('body')).toContainText('Bluem request(s)');
-  await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
-
-  await page.goto(`/wp-admin/admin.php?page=bluem-transactions&request_id=${requestId}`);
-  await expect(page.locator('h1')).toContainText('Transaction details');
-  await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
+  await page.goto('/wp-admin/admin.php?page=bluem-settings');
+  await expect(page.locator('h1')).toContainText('Settings');
+  await page.locator('a[data-tab="account"]').click();
+  await expect(page.locator('#bluem_woocommerce_settings_senderID')).toBeVisible();
+  await expect(page.locator('#bluem_woocommerce_settings_environment')).toBeVisible();
+  await page.locator('#bluem_woocommerce_settings_senderID').fill('S123456');
+  await page.locator('#bluem_woocommerce_settings_environment').selectOption('test');
+  await page.locator('input[name="submit"]').click();
+  await page.goto('/wp-admin/admin.php?page=bluem-settings');
+  await expect(page.locator('#bluem_woocommerce_settings_senderID')).toHaveValue('S123456');
 });

--- a/tests/playwright/bluem-admin.spec.ts
+++ b/tests/playwright/bluem-admin.spec.ts
@@ -51,9 +51,9 @@ test('administrator can inspect the fixture order and Bluem transaction', async 
 
   await page.goto(`/wp-admin/admin.php?page=wc-orders&action=edit&id=${orderId}`);
   await expect(page.locator('body')).toContainText('Bluem request(s)');
-  await expect(page.locator('body')).toContainText('ACCEPTANCE-TRANSACTION-1');
+  await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
 
   await page.goto(`/wp-admin/admin.php?page=bluem-transactions&request_id=${requestId}`);
-  await expect(page.locator('body')).toContainText('ACCEPTANCE-TRANSACTION-1');
+  await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
   await expect(page.locator('body')).toContainText('Bluem acceptance fixture payment');
 });

--- a/tests/playwright/bluem-admin.spec.ts
+++ b/tests/playwright/bluem-admin.spec.ts
@@ -5,6 +5,7 @@ async function login(page: Page) {
   await page.locator('input[name="log"]').fill('wordpress');
   await page.locator('input[name="pwd"]').fill('wordpress');
   await page.locator('#wp-submit').click();
+  await expect(page.locator('#wpadminbar')).toBeVisible();
 }
 
 test('administrator can inspect the fixture order and Bluem transaction', async ({ page }) => {
@@ -28,7 +29,7 @@ test('administrator can deactivate and reactivate Bluem', async ({ page }) => {
   await login(page);
   await page.goto('/wp-admin/plugins.php');
 
-  const pluginRow = page.locator('#the-list tr').filter({ hasText: 'Bluem ePayments' });
+  const pluginRow = page.locator('#the-list tr[data-plugin="bluem/bluem.php"]:not(.plugin-update-tr)');
   await expect(pluginRow).toBeVisible();
   await pluginRow.getByRole('link', { name: 'Deactivate' }).click();
   await expect(pluginRow.getByRole('link', { name: 'Activate' })).toBeVisible();

--- a/tests/playwright/bluem-admin.spec.ts
+++ b/tests/playwright/bluem-admin.spec.ts
@@ -32,13 +32,25 @@ test('administrator can deactivate and reactivate Bluem', async ({ page }) => {
   await expect(pluginRow.getByRole('link', { name: 'Activate' })).toBeVisible();
   await pluginRow.getByRole('link', { name: 'Activate' }).click();
   await expect(pluginRow.getByRole('link', { name: 'Deactivate' })).toBeVisible();
+
+  // Activation resets Bluem's setup guard. Complete the local, non-production
+  // activation form so later browser tests can use normal admin pages.
+  await page.goto('/wp-admin/admin.php?page=bluem-activate');
+  await page.locator('#company_name').fill('Bluem Acceptance');
+  await page.locator('#company_telephone').fill('0200000000');
+  await page.locator('#company_email').fill('acceptance@example.com');
+  await page.locator('#tech_name').fill('Bluem Acceptance Tester');
+  await page.locator('#tech_telephone').fill('0200000001');
+  await page.locator('#tech_email').fill('tester@example.com');
+  await page.locator('#activateform input[type="submit"]').click();
+  await expect(page.locator('body')).toContainText('The plugin has been activated');
 });
 
 test('administrator can open WooCommerce payment settings', async ({ page }) => {
   await login(page);
   await page.goto('/wp-admin/admin.php?page=wc-settings&tab=checkout');
-  await expect(page.locator('body')).toContainText('Bluem iDEAL Acceptance');
-  await expect(page.locator('body')).toContainText('Bluem PayPal');
+  await expect(page.locator('body')).toContainText('Bluem payments via iDEAL');
+  await expect(page.locator('body')).toContainText('Bluem payments via PayPal');
 });
 
 test('administrator can inspect the fixture order and Bluem transaction', async ({ page }) => {
@@ -54,6 +66,6 @@ test('administrator can inspect the fixture order and Bluem transaction', async 
   await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
 
   await page.goto(`/wp-admin/admin.php?page=bluem-transactions&request_id=${requestId}`);
+  await expect(page.locator('h1')).toContainText('Transaction details');
   await expect(page.locator('body')).toContainText('ACCEPTANCETX1');
-  await expect(page.locator('body')).toContainText('Bluem acceptance fixture payment');
 });

--- a/tests/playwright/bluem-admin.spec.ts
+++ b/tests/playwright/bluem-admin.spec.ts
@@ -1,14 +1,59 @@
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 
-test('administrator can open Bluem settings', async ({ page }) => {
+async function login(page: Page) {
   await page.goto('/wp-login.php');
   await page.locator('input[name="log"]').fill('wordpress');
   await page.locator('input[name="pwd"]').fill('wordpress');
   await page.locator('#wp-submit').click();
+}
+
+test('administrator can open Bluem settings and persist a change', async ({ page }) => {
+  await login(page);
 
   await page.goto('/wp-admin/admin.php?page=bluem-settings');
   await expect(page.locator('h1')).toContainText('Settings');
   await page.locator('a[data-tab="account"]').click();
   await expect(page.locator('#bluem_woocommerce_settings_senderID')).toBeVisible();
   await expect(page.locator('#bluem_woocommerce_settings_environment')).toBeVisible();
+  await page.locator('#bluem_woocommerce_settings_senderID').fill('playwright-acceptance-sender');
+  await page.locator('#bluem_woocommerce_settings_environment').selectOption('test');
+  await page.locator('input[name="submit"]').click();
+  await page.goto('/wp-admin/admin.php?page=bluem-settings');
+  await expect(page.locator('#bluem_woocommerce_settings_senderID')).toHaveValue('playwright-acceptance-sender');
+});
+
+test('administrator can deactivate and reactivate Bluem', async ({ page }) => {
+  await login(page);
+  await page.goto('/wp-admin/plugins.php');
+
+  const pluginRow = page.locator('#the-list tr').filter({ hasText: 'Bluem ePayments' });
+  await expect(pluginRow).toBeVisible();
+  await pluginRow.getByRole('link', { name: 'Deactivate' }).click();
+  await expect(pluginRow.getByRole('link', { name: 'Activate' })).toBeVisible();
+  await pluginRow.getByRole('link', { name: 'Activate' }).click();
+  await expect(pluginRow.getByRole('link', { name: 'Deactivate' })).toBeVisible();
+});
+
+test('administrator can open WooCommerce payment settings', async ({ page }) => {
+  await login(page);
+  await page.goto('/wp-admin/admin.php?page=wc-settings&tab=checkout');
+  await expect(page.locator('body')).toContainText('Bluem iDEAL Acceptance');
+  await expect(page.locator('body')).toContainText('Bluem PayPal');
+});
+
+test('administrator can inspect the fixture order and Bluem transaction', async ({ page }) => {
+  await login(page);
+
+  const orderId = process.env.WP_ACCEPTANCE_FIXTURE_ORDER_ID;
+  const requestId = process.env.WP_ACCEPTANCE_FIXTURE_REQUEST_ID;
+  expect(orderId).toBeTruthy();
+  expect(requestId).toBeTruthy();
+
+  await page.goto(`/wp-admin/admin.php?page=wc-orders&action=edit&id=${orderId}`);
+  await expect(page.locator('body')).toContainText('Bluem request(s)');
+  await expect(page.locator('body')).toContainText('ACCEPTANCE-TRANSACTION-1');
+
+  await page.goto(`/wp-admin/admin.php?page=bluem-transactions&request_id=${requestId}`);
+  await expect(page.locator('body')).toContainText('ACCEPTANCE-TRANSACTION-1');
+  await expect(page.locator('body')).toContainText('Bluem acceptance fixture payment');
 });


### PR DESCRIPTION
## Summary

- Add a cost-free Bluem HTTP transport seam and scoped Docker mock responses.
- Add reusable WooCommerce fixtures and an end-to-end Make target covering admin, plugin lifecycle, settings, gateways, order metaboxes, transaction details, request creation, callbacks, and Pending status handling.
- Add Chromium browser coverage and a dedicated CI job with failure diagnostics.
- Ignore generated Playwright reports and document known admin-status limitations.

## Why

This gives future plugin changes a broad local regression safety net without contacting the Bluem API or creating billable requests.

## Validation

- `make acceptance_e2e_test`
- Codeception: 8 tests, 18 assertions
- Mocked callback: HTTP 302 and order transition to processing
- Mocked Pending callback: order remains pending and request status persists
- Playwright: 4/4 Chromium tests
- PHP lint, `git diff --check`, and Docker Compose config validation

## Notes

The unrelated local file `src/Observability/SentryTestingPage.php` is intentionally not included.
