### PR TITLE
Fix admin URLs for Bluem settings links

### DIFF
--- a/bluem-payments.php
+++ b/bluem-payments.php
@@ -40,7 +40,7 @@ function bluem_woocommerce_payments_settings_section()
 {
     echo '<p><a id="tab_payments"></a>
 <strong>Note: in addition to configuring the functions below, you must also activate the payment methods in the
-<a href="' . (esc_url(home_url()) . 'wp-admin/admin.php?page=wc-settings&tab=checkout') . '" target="_blank">WooCommerce payment settings</a>.
+<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout' ) ) . '" target="_blank">WooCommerce payment settings</a>.
 </strong><br>
     Here you can configure important details for ePayments transactions so you can easily receive payments.</p>
     <p>Read <a href="' . esc_url(BLUEM_WOOCOMMERCE_MANUAL_URL) . '" target="_blank">the manual</a> for more information.</p>';

--- a/bluem.php
+++ b/bluem.php
@@ -1413,7 +1413,7 @@ function bluem_woocommerce_show_general_profile_fields() {
                 printf(
                 /* translators: %s: link to bluem settings */
                         esc_html__( 'Go to the <a href="%s">
-                    settings</a> to change the behavior of each Bluem component.', 'bluem' ), esc_url( home_url( "wp-admin/admin.php?page=bluem-settings" ) ) );
+                    settings</a> to change the behavior of each Bluem component.', 'bluem' ), esc_url( admin_url( 'admin.php?page=bluem-settings' ) ) );
                 ?>
             </td>
         </tr>


### PR DESCRIPTION
## What

Replaced two manually assembled WordPress admin URLs with `admin_url()`:

- WooCommerce payment settings link
- Bluem settings link in the user profile section

## Why

`admin_url()` is WordPress's canonical URL builder for the administration area. It remains correct for subdirectory, mapped, or otherwise non-standard WordPress installations, while `home_url() . 'wp-admin/...'` assumes an admin path relative to the public site URL.

## Impact

No public routes, callbacks, permalink behavior, or visible text changes. The two existing settings links become more installation-safe.

## Validation

- `php -l bluem.php`
- `php -l bluem-payments.php`
- `git diff --check`
