### PR TITLE
Refactor shared browser acceptance runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,14 +114,18 @@ playwright_install:
 	npm install --no-audit --no-fund
 	npx playwright install chromium
 
-.PHONY: acceptance_browser_test
-acceptance_browser_test: acceptance_checkout_prepare playwright_install
-	@printf 'Playwright browser tests:\n';
+.PHONY: acceptance_browser_run
+acceptance_browser_run:
 	@order_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id); \
 		request_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id); \
 		export WP_ACCEPTANCE_FIXTURE_ORDER_ID=$$order_id; \
 		export WP_ACCEPTANCE_FIXTURE_REQUEST_ID=$$request_id; \
 		npm run test:e2e
+
+.PHONY: acceptance_browser_test
+acceptance_browser_test: acceptance_checkout_prepare playwright_install
+	@printf 'Playwright browser tests:\n';
+	@$(MAKE) --no-print-directory acceptance_browser_run
 
 .PHONY: acceptance_e2e_test
 acceptance_e2e_test: playwright_install
@@ -140,12 +144,8 @@ acceptance_e2e_test: playwright_install
 		docker compose run --rm wpcli --allow-root rewrite flush --hard; \
 		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-mandate-flow.php; \
 		docker compose run --rm wpcli --allow-root eval-file /opt/bluem-scripts/acceptance-test-identity-flow.php
-	@order_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_order_id); \
-		request_id=$$(docker compose run --rm wpcli --allow-root option get bluem_acceptance_fixture_request_id); \
-		export WP_ACCEPTANCE_FIXTURE_ORDER_ID=$$order_id; \
-		export WP_ACCEPTANCE_FIXTURE_REQUEST_ID=$$request_id; \
-		export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
-		npm run test:e2e
+	@export BLUEM_ACCEPTANCE_MOCK_URL=http://mock-bluem:8080/; \
+		$(MAKE) --no-print-directory acceptance_browser_run
 
 .PHONY: integration_test
 integration_test:


### PR DESCRIPTION
## What

Extracted the repeated Playwright fixture handoff into the internal `acceptance_browser_run` Make target.

`acceptance_browser_test` and `acceptance_e2e_test` retain their existing public names, prerequisites, setup, and execution order; both now delegate the final browser invocation to the shared target.

## Why

The browser fixture-ID export and Playwright invocation appeared in two places. Keeping that behavior in one target makes future E2E additions easier to triage and prevents the browser paths from drifting.

## Impact

No CI job, public developer command, test scope, or mock behavior changes. The E2E target still exports `BLUEM_ACCEPTANCE_MOCK_URL` before invoking the shared runner.

## Validation

- `make -n acceptance_browser_run`
- `make -n acceptance_browser_test`
- `make -n acceptance_e2e_test`
- `git diff --check`
